### PR TITLE
fix: adjustment dockerfile permissions

### DIFF
--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -2,6 +2,10 @@ FROM ruby:3.4.5
 
 RUN apt-get update -qq && apt-get install -y curl build-essential libpq-dev
 
+ARG UID=1000
+ARG GID=1000
+RUN groupadd -g $GID appuser && useradd -m -u $UID -g appuser appuser
+
 WORKDIR /app
 
 COPY Gemfile Gemfile.lock ./
@@ -12,6 +16,10 @@ COPY . .
 COPY entrypoint.sh /usr/bin/entrypoint.sh
 RUN chmod +x /usr/bin/entrypoint.sh
 
+USER appuser
+
 EXPOSE 3000
 
-CMD ["sh", "/usr/bin/entrypoint.sh"]
+ENTRYPOINT ["/usr/bin/entrypoint.sh"]
+
+CMD ["bin/setup", "-b", "0.0.0.0", "-p", "3000"]

--- a/bin/setup
+++ b/bin/setup
@@ -29,6 +29,6 @@ FileUtils.chdir APP_ROOT do
   unless ARGV.include?("--skip-server")
     puts "\n== Starting development server =="
     STDOUT.flush # flush the output before exec(2) so that it displays
-    exec "bin/dev"
+    exec "bin/dev", *ARGV
   end
 end

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,14 +3,13 @@ services:
     build:
       context: .
       dockerfile: Dockerfile.dev
-    entrypoint: entrypoint.sh
     env_file:
       - .env
     ports:
       - '3000:3000'
     volumes:
       - .:/app
-    command: ./bin/rails server -b 0.0.0.0 -p 3000
+      - ruby_gems:/usr/local/bundle
     depends_on:
       - db
   db:
@@ -23,3 +22,4 @@ services:
       - postgres:/var/lib/postgresql/data
 volumes:
   postgres:
+  ruby_gems:


### PR DESCRIPTION
## 📌 Motivação

Atualmente, o container está sendo executado como root, o que faz com que arquivos gerados pela aplicação (como migrations, logs, etc.) sejam criados com permissões elevadas. Isso impede que esses arquivos sejam editados ou removidos localmente sem o uso de sudo, atrapalhando o fluxo de desenvolvimento.

Além disso, o comando para subir o servidor com docker-compose estava desatualizado, considerando as mudanças introduzidas no Rails 8 (uso do bin/setup e bin/dev).

## 🔧 O que foi feito

* Ajustado o Dockerfile para que o container execute com um usuário que tenha o mesmo UID/GID do host, evitando problemas de permissão de arquivos.

* Criado usuário appuser com variáveis ARG UID e GID.

* Definido USER appuser ao final do Dockerfile.

* Corrigido o CMD no Dockerfile para utilizar o bin/setup, que agora é responsável por subir o servidor com base nos argumentos recebidos.

* Removido o campo command: do docker-compose.yml, que passou a ser desnecessário.

* Documentado o novo fluxo de subida do servidor, considerando a estrutura do Rails 8:

- bin/setup → bin/dev → rails server


## 📎 Card relacionado

[Ajustar Dockerfile para resolver problemas de permissões e docker-compose para subir server](https://app.asana.com/1/1210874620328007/project/1210874306355308/task/1210944067809771)

