### PR TITLE
[BS-makefile] Adicionar Makefile para automação de comandos com docker compose

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,47 @@
+.PHONY: exec cop rspec suit logs web up down migrate rollback console bash _ensure_up
+
+SERVICE = backend
+
+_ensure_up:
+	@if [ -z "$$(docker compose ps -q --status=running $(SERVICE))" ]; then \
+		echo "🚀 Starting $(SERVICE) service..."; \
+		docker compose up -d --no-build $(SERVICE); \
+	fi
+
+exec: _ensure_up
+	docker compose exec $(SERVICE) $(CMD)
+
+cop: _ensure_up
+	docker compose exec $(SERVICE) bundle exec rubocop
+
+rspec: _ensure_up
+	docker compose exec $(SERVICE) bundle exec rspec
+
+suit: cop rspec
+
+logs:
+	@echo "📜  Acompanhando os logs do backend..."
+	@docker compose logs -f $(SERVICE)
+
+web:
+	@$(MAKE) logs
+
+up:
+	@docker compose up -d --build
+
+down:
+	docker compose down
+
+start: up logs
+
+migrate: _ensure_up
+	docker compose exec $(SERVICE) bin/rails db:migrate
+
+rollback: _ensure_up
+	docker compose exec $(SERVICE) bin/rails db:rollback
+
+console: _ensure_up
+	docker compose exec $(SERVICE) bin/rails console
+
+bash: _ensure_up
+	docker compose exec $(SERVICE) bash

--- a/Makefile
+++ b/Makefile
@@ -1,47 +1,59 @@
-.PHONY: exec cop rspec suit logs web up down migrate rollback console bash _ensure_up
+.PHONY: exec cop rspec suit logs web up build down migrate rollback console bash _ensure_up help
 
 SERVICE = backend
 
-_ensure_up:
+_ensure_up: ## Garante que o serviço $(SERVICE) está rodando
 	@if [ -z "$$(docker compose ps -q --status=running $(SERVICE))" ]; then \
 		echo "🚀 Starting $(SERVICE) service..."; \
 		docker compose up -d --no-build $(SERVICE); \
 	fi
 
-exec: _ensure_up
+exec: _ensure_up ## Executa um comando dentro do container backend (use CMD="seu comando")
 	docker compose exec $(SERVICE) $(CMD)
 
-cop: _ensure_up
+cop: _ensure_up ## Roda o RuboCop dentro do container
 	docker compose exec $(SERVICE) bundle exec rubocop
 
-rspec: _ensure_up
-	docker compose exec $(SERVICE) bundle exec rspec
+rspec: _ensure_up ## Roda os testes RSpec (use SPEC="spec/path" para rodar testes específicos)
+	docker compose exec $(SERVICE) bundle exec rspec $(SPEC)
 
-suit: cop rspec
+suit: cop rspec ## Roda RuboCop e RSpec em sequência
 
-logs:
+logs: ## Mostra os logs em tempo real do backend
 	@echo "📜  Acompanhando os logs do backend..."
 	@docker compose logs -f $(SERVICE)
 
-web:
-	@$(MAKE) logs
+web: ## Sobe o backend com portas expostas em modo interativo
+	docker compose run --service-ports backend
 
-up:
-	@docker compose up -d --build
+up: ## Sobe todos os serviços em background
+	@docker compose up -d
 
-down:
-	docker compose down
+build: ## Rebuilda as imagens Docker
+	docker compose build
 
-start: up logs
+down: ## Para e remove containers, volumes e órfãos
+	docker compose down -v --remove-orphans
 
-migrate: _ensure_up
+start: up logs ## Sobe os serviços e exibe os logs
+
+migrate: _ensure_up ## Executa as migrações do banco
 	docker compose exec $(SERVICE) bin/rails db:migrate
 
-rollback: _ensure_up
+rollback: _ensure_up ## Faz rollback da última migração
 	docker compose exec $(SERVICE) bin/rails db:rollback
 
-console: _ensure_up
+console: _ensure_up ## Abre um console Rails dentro do container
 	docker compose exec $(SERVICE) bin/rails console
 
-bash: _ensure_up
+bash: _ensure_up ## Abre um bash dentro do container
 	docker compose exec $(SERVICE) bash
+
+clean: ## Remove containers parados
+	docker container prune -f
+
+help: ## Mostra esta ajuda
+	@echo "Comandos disponíveis:"
+	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) \
+		| sort \
+		| awk 'BEGIN {FS = ":.*?## "}; {printf "  \033[36m%-15s\033[0m %s\n", $$1, $$2}'

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 
 SERVICE = backend
 
-_ensure_up: ## Garante que o serviço $(SERVICE) está rodando
+_ensure_up: ## Garante que o serviço $(SERVICE) esteja em execução
 	@if [ -z "$$(docker compose ps -q --status=running $(SERVICE))" ]; then \
 		echo "🚀 Starting $(SERVICE) service..."; \
 		docker compose up -d $(SERVICE); \
@@ -11,14 +11,14 @@ _ensure_up: ## Garante que o serviço $(SERVICE) está rodando
 exec: _ensure_up ## Executa um comando dentro do container backend (use CMD="seu comando")
 	@docker compose exec $(SERVICE) $(CMD)
 
-cop: _ensure_up ## Roda o RuboCop dentro do container
+cop: _ensure_up ## Executa o RuboCop dentro do container
 	@docker compose exec $(SERVICE) bundle exec rubocop
 
-rspec: _ensure_up ## Roda os testes RSpec (use SPEC="spec/path" para rodar testes específicos)
+rspec: _ensure_up ## Executa os testes RSpec (use SPEC="spec/path" para executar testes específicos)
 	@docker compose exec $(SERVICE) bin/rails db:prepare RAILS_ENV=test
 	@docker compose exec $(SERVICE) bundle exec rspec $(filter-out $@,$(MAKECMDGOALS))
 
-suit: _ensure_up ## Roda RuboCop e RSpec em sequência
+suit: _ensure_up ## Executa RuboCop e RSpec em sequência
 	@docker compose exec $(SERVICE) bundle exec rubocop
 	@docker compose exec $(SERVICE) bin/rails db:prepare RAILS_ENV=test
 	@docker compose exec $(SERVICE) bundle exec rspec $(filter-out $@,$(MAKECMDGOALS))
@@ -30,33 +30,33 @@ logs: ## Mostra os logs em tempo real do backend
 web: ## Sobe o backend com portas expostas em modo interativo
 	@docker compose run --service-ports backend
 
-up: ## Sobe todos os serviços em background
+up: ## Inicia todos os serviços em segundo plano
 	@docker compose up -d
 
-build: ## Rebuilda as imagens Docker
+build: ## Reconstrói as imagens Docker
 	@docker compose build
 
-down: ## Para e remove containers, volumes e órfãos
+down: ## Encerra e remove volumes e containers órfãos
 	@docker compose down -v --remove-orphans
 
-start: up logs ## Sobe os serviços e exibe os logs
+start: up logs ## Inicia todos os serviços e exibe os logs
 
-migrate: _ensure_up ## Executa as migrações do banco
+migrate: _ensure_up ## Executa as migrações do banco de dados
 	@docker compose exec $(SERVICE) bin/rails db:migrate
 
-rollback: _ensure_up ## Faz rollback da última migração
+rollback: _ensure_up ## Reverte a última migração do banco de dados
 	@docker compose exec $(SERVICE) bin/rails db:rollback
 
 console: _ensure_up ## Abre um console Rails dentro do container
 	@docker compose exec $(SERVICE) bin/rails console
 
-bash: _ensure_up ## Abre um bash dentro do container
+bash: _ensure_up ## Abre um terminal bash dentro do container
 	@docker compose exec $(SERVICE) bash
 
-clean: ## Remove containers parados
+clean: ## Remove containers, volumes e imagens não utilizados
 	@docker system prune -a --volumes -f
 
-help: ## Mostra esta ajuda
+help: ## Exibe esta lista de comandos
 	@echo "Comandos disponíveis:"
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) \
 		| sort \

--- a/Makefile
+++ b/Makefile
@@ -15,13 +15,11 @@ cop: _ensure_up ## Executa o RuboCop dentro do container
 	@docker compose exec $(SERVICE) bundle exec rubocop
 
 rspec: _ensure_up ## Executa os testes RSpec (use SPEC="spec/path" para executar testes específicos)
-	@docker compose exec $(SERVICE) bin/rails db:prepare RAILS_ENV=test
-	@docker compose exec $(SERVICE) bundle exec rspec $(filter-out $@,$(MAKECMDGOALS))
+	@docker compose exec $(SERVICE) bin/rails db:prepare RAILS_ENV=test && docker compose exec $(SERVICE) bundle exec rspec $(filter-out $@,$(MAKECMDGOALS))
+
 
 suit: _ensure_up ## Executa RuboCop e RSpec em sequência
-	@docker compose exec $(SERVICE) bundle exec rubocop
-	@docker compose exec $(SERVICE) bin/rails db:prepare RAILS_ENV=test
-	@docker compose exec $(SERVICE) bundle exec rspec $(filter-out $@,$(MAKECMDGOALS))
+	@docker compose exec $(SERVICE) bundle exec rubocop && docker compose exec $(SERVICE) bin/rails db:prepare RAILS_ENV=test && docker compose exec $(SERVICE) bundle exec rspec $(filter-out $@,$(MAKECMDGOALS))
 
 logs: ## Mostra os logs em tempo real do backend
 	@echo "📜 Acompanhando os logs do backend..."
@@ -61,3 +59,6 @@ help: ## Exibe esta lista de comandos
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) \
 		| sort \
 		| awk 'BEGIN {FS = ":.*?## "}; {printf "  \033[36m%-15s\033[0m %s\n", $$1, $$2}'
+
+%:
+	@:


### PR DESCRIPTION
## 📌 Motivação

Atualmente, para executar tarefas do projeto, é necessário digitar comandos longos do docker compose, o que torna o fluxo de desenvolvimento repetitivo e sujeito a erros.
A criação de um Makefile visa centralizar e simplificar essas operações, proporcionando maior produtividade e padronização para toda a equipe.

## 🔧 O que foi feito

* Criado Makefile na raiz do projeto.

* Adicionados targets para:

* Subir e derrubar containers (make up, make down, make start).

* Acompanhar logs do backend (make logs, make web).

* Executar Rubocop e RSpec (make cop, make rspec, make suit).

* Executar migrações e rollback de banco (make migrate, make rollback).

* Abrir console Rails e bash (make console, make bash).


* Criado target auxiliar _ensure_up que garante que o serviço backend esteja rodando antes da execução de qualquer comando.


## 📎 Card relacionado

[Adicionar Makefile para automação de comandos com Docker Compose](https://app.asana.com/1/1210874620328007/project/1210990422521317/task/1211402244541822)
