### PR TITLE
[BS-03][BACKEND] Exibir detalhes de um livro

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,2 @@
+bash:
+	docker compose run --rm backend bash

--- a/backend/app/controllers/api/v1/books_controller.rb
+++ b/backend/app/controllers/api/v1/books_controller.rb
@@ -3,4 +3,9 @@ class Api::V1::BooksController < ApplicationController
     books = Book.all
     render json: BookSerializer.new(books).serializable_hash
   end
+
+  def show
+    book = Book.find(params[:id])
+    render json: BookSerializer.new(book).serializable_hash
+  end
 end

--- a/backend/app/serializers/book_serializer.rb
+++ b/backend/app/serializers/book_serializer.rb
@@ -1,7 +1,7 @@
 class BookSerializer
   include JSONAPI::Serializer
 
-  attributes :title, :author_name, :price
+  attributes :title, :author_name, :price, :synopsis
 
   attribute :cover_image_url do |object|
     Rails.application.routes.url_helpers.url_for(object.cover_image) if object.cover_image.attached?

--- a/backend/config/routes.rb
+++ b/backend/config/routes.rb
@@ -1,7 +1,7 @@
 Rails.application.routes.draw do
   namespace :api do
     namespace :v1 do
-      resources :books, only: 'index'
+      resources :books, only: %i[index show]
     end
   end
 end

--- a/backend/db/migrate/20250908123611_add_synopsis_to_books.rb
+++ b/backend/db/migrate/20250908123611_add_synopsis_to_books.rb
@@ -1,0 +1,5 @@
+class AddSynopsisToBooks < ActiveRecord::Migration[8.0]
+  def change
+    add_column :books, :synopsis, :text
+  end
+end

--- a/backend/db/schema.rb
+++ b/backend/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_09_05_115132) do
+ActiveRecord::Schema[8.0].define(version: 2025_09_08_123611) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -48,6 +48,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_09_05_115132) do
     t.decimal "price"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.text "synopsis"
   end
 
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"

--- a/backend/spec/factories/books.rb
+++ b/backend/spec/factories/books.rb
@@ -3,6 +3,7 @@ FactoryBot.define do
     title { Faker::Book.title }
     author_name { Faker::Book.author }
     price { Faker::Commerce.price(range: 10.0..100.0) }
+    synopsis { Faker::Lorem.paragraph }
 
     after(:build) do |book|
       image_path = Dir.glob(Rails.root.join('spec/fixtures/files/*')).sample

--- a/backend/spec/requests/books_api_spec.rb
+++ b/backend/spec/requests/books_api_spec.rb
@@ -43,4 +43,54 @@ describe 'Books Api', type: :request do
       end
     end
   end
+
+  context 'GET /api/v1/books/:id' do
+    context 'when the request is successful' do
+      it 'and return a book'do
+        file = Rack::Test::UploadedFile.new(Rails.root.join('spec/fixtures/files/capa_a_culpa.jpg'), 'image/jpeg')
+
+        book = create(
+          :book,
+          title: 'A culpa é das Estrelas',
+          author_name: 'John Green',
+          cover_image: file,
+          price: 25.00,
+          synopsis: "Hazel Grace Lancaster e Augustus Waters são dois adolescentes que se conhecem em um grupo de apoio " \
+          "para pacientes com câncer. Por causa da doença, Hazel sempre descartou a ideia de se envolver amorosamente, " \
+          "mas acaba cedendo ao se apaixonar por Augustus. Juntos, eles viajam para Amsterdã, onde embarcam em uma jornada " \
+          "inesquecível."
+        )
+        book02 = create(
+          :book,
+          title: '1984',
+          author_name: 'George Orwell',
+          cover_image: file,
+          price: 10.00,
+          synopsis: "Romance distópico que retrata a vida na Oceania, uma sociedade totalitária controlada pelo Partido " \
+          "e seu líder onipresente, o Grande Irmão."
+        )
+
+        get "/api/v1/books/#{book.id}"
+
+        expect(response).to have_http_status(:ok)
+        expect(response_data[:attributes][:title]).to eq('A culpa é das Estrelas')
+        expect(response_data[:attributes][:author_name]).to eq('John Green')
+        expect(response_data[:attributes][:cover_image_url]).to be_present
+        expect(response_data[:attributes][:price]).to eq('25.0')
+        expect(response_data[:attributes][:synopsis]).to be_present
+
+        expect(response_data[:attributes][:title]).to_not eq('1984')
+        expect(response_data[:attributes][:author_name]).to_not eq('George Orwell')
+        expect(response_data[:attributes][:price]).to_not eq('10.0')
+      end
+
+      context 'when the book does not exist' do
+        it 'and return a 404' do
+          get '/api/v1/books/999'
+
+          expect(response).to have_http_status(:not_found)
+        end
+      end
+    end
+  end
 end

--- a/backend/spec/requests/books_api_spec.rb
+++ b/backend/spec/requests/books_api_spec.rb
@@ -34,7 +34,7 @@ describe 'Books Api', type: :request do
 
   context 'GET /api/v1/books/:id' do
     context 'when the request is successful' do
-      it 'and return a book'do
+      it 'and return a book' do
         file = Rack::Test::UploadedFile.new(Rails.root.join('spec/fixtures/files/capa_a_culpa.jpg'), 'image/jpeg')
 
         book = create(

--- a/backend/spec/serializer/book_serializer_spec.rb
+++ b/backend/spec/serializer/book_serializer_spec.rb
@@ -11,6 +11,7 @@ describe BookSerializer, type: :serializer do
       expect(serialized[:data][:attributes][:author_name]).to eq('John Green')
       expect(serialized[:data][:attributes][:cover_image_url]).to be_present
       expect(serialized[:data][:attributes][:price].to_f).to eq(25.0)
+      expect(serialized[:data][:attributes][:synopsis]).to be_present
     end
 
     it 'returns the expected keys in attributes' do
@@ -22,6 +23,7 @@ describe BookSerializer, type: :serializer do
           author_name
           price
           cover_image_url
+          synopsis
         ]
       )
     end


### PR DESCRIPTION
## 📌 Motivação

Atualmente, não existe uma rota pública para obter os detalhes de um livro específico.
Essa funcionalidade é necessária para que o frontend, em futuras implementações, consiga consumir a API e exibir as informações completas de um livro quando o usuário acessar sua página de detalhes.

## 🔧 O que foi feito

* Implementada rota pública GET /api/v1/books/:id.
* Adicionado endpoint no controller para buscar e retornar os detalhes de um livro específico.
* Estruturado serializer/JSON de resposta com os campos obrigatórios:
* id (inteiro)
* title (string)
* author_name (string)
* cover_image_url (string)
* synopsis (text)
* Criado teste de request para validar o formato e os dados retornados pela API.

## 📎 Card relacionado

 [[BS-03][BACKEND] Exibir detalhes de um livro](https://app.asana.com/1/1210874620328007/project/1210990422521317/task/1210998192115812)

